### PR TITLE
Projection Lock feature added

### DIFF
--- a/ESProjections.1.0.1.nuspec
+++ b/ESProjections.1.0.1.nuspec
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>ESProjections</id>
+    <version>1.0.2</version>
+    <authors>Tacta.EventSourcing.Projections</authors>
+    <owners>Tacta.EventSourcing.Projections</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/tacta-io/es-projections/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/tacta-io/es-projections</projectUrl>
+    <iconUrl>https://tacta.io//wp-content/uploads/2018/10/tacta_logo_neg.png</iconUrl>
+    <description>Provides a simple way of incrementally building / rebuilding read model projections for .NET projects</description>
+    <repository type="git" url="https://github.com/tacta-io/es-projections" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="C:\projects\es-projections\Tacta.EventSourcing.Projections\bin\Debug\netstandard2.0\Tacta.EventSourcing.Projections.dll" target="lib\netstandard2.0\Tacta.EventSourcing.Projections.dll" />
+  </files>
+</package>

--- a/Tacta.EventSourcing.Projections.Tests/Tacta.EventSourcing.Projections.Tests.csproj
+++ b/Tacta.EventSourcing.Projections.Tests/Tacta.EventSourcing.Projections.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,14 +40,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.4.0.0\lib\net46\NSubstitute.dll</HintPath>
@@ -55,8 +55,11 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -66,6 +69,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -80,8 +84,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/Tacta.EventSourcing.Projections.Tests/app.config
+++ b/Tacta.EventSourcing.Projections.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tacta.EventSourcing.Projections.Tests/packages.config
+++ b/Tacta.EventSourcing.Projections.Tests/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.3.1" targetFramework="net471" />
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net471" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net471" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net471" />
+  <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net471" />
+  <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net471" />
   <package id="NSubstitute" version="4.0.0" targetFramework="net471" />
-  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net471" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net471" />
 </packages>

--- a/Tacta.EventSourcing.Projections/IProjectionLock.cs
+++ b/Tacta.EventSourcing.Projections/IProjectionLock.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Tacta.EventSourcing.Projections
+{
+    public interface IProjectionLock
+    {
+        Task<bool> IsActiveProjection(string activeIdentity);
+    }
+}

--- a/Tacta.EventSourcing.Projections/ProjectionAgent.cs
+++ b/Tacta.EventSourcing.Projections/ProjectionAgent.cs
@@ -13,6 +13,7 @@ namespace Tacta.EventSourcing.Projections
             public int BatchSize { get; set; } = 100;
 
             public double PeekIntervalMilliseconds { get; set; } = 1000;
+ 
         }
 
         private readonly Configuration _configuration = new Configuration();
@@ -24,13 +25,29 @@ namespace Tacta.EventSourcing.Projections
         private readonly List<IProjection> _projections;
 
         private bool _dispatchInProgress;
+        private readonly IProjectionLock _projectionLock;
+        private readonly string _activeIdentity;
 
-        public ProjectionAgent(IEventStream eventStream, IProjection[] projections)
+        public ProjectionAgent(IEventStream eventStream,
+            IProjection[] projections,
+            IProjectionLock projectionLock = null, 
+            string activeIdentity = null)
         {
             _eventStream = eventStream ?? throw new InvalidEnumArgumentException("ProjectionAgent: You have to provide an event stream");
             _projections = projections.ToList();
-
+            
             if (_projections == null) Console.WriteLine("ProjectionAgent: No projections registered");
+
+            if (IsUsingLocking(projectionLock, activeIdentity))
+            {
+                _projectionLock = projectionLock;
+                _activeIdentity = activeIdentity;
+            }
+        }
+
+        private static bool IsUsingLocking(IProjectionLock projectionLock, string activeIdentity)
+        {
+            return projectionLock != null && activeIdentity != null;
         }
 
         public IDisposable Run(Action<Configuration> config)
@@ -52,10 +69,40 @@ namespace Tacta.EventSourcing.Projections
             return _timer;
         }
 
-        public void OnTimer(object source, ElapsedEventArgs e)
+        private bool IsProjectionActive()
         {
-            if (_dispatchInProgress) return;
+            return _projectionLock.IsActiveProjection(_activeIdentity).GetAwaiter().GetResult();
+        }
 
+        private void OnTimer(object source, ElapsedEventArgs e)
+        {
+            if (_dispatchInProgress)
+            {
+                //refresh timer if rebuild lasts longer
+                IsProjectionActive();
+                return;
+            }
+
+            if (IsUsingLocking(_projectionLock, _activeIdentity))
+            {
+                if (IsProjectionActive())
+                {
+                    ProjectEvents();
+                    Console.WriteLine($"Process {_activeIdentity} is now projecting");
+                }
+                else
+                {
+                    Console.WriteLine($"Process {_activeIdentity} is not active");
+                }
+            }
+            else
+            {
+                ProjectEvents();
+            }
+        }
+
+        private void ProjectEvents()
+        {
             try
             {
                 ToggleDispatchProgress();

--- a/Tacta.EventSourcing.Projections/ProjectionAgent.cs
+++ b/Tacta.EventSourcing.Projections/ProjectionAgent.cs
@@ -74,7 +74,7 @@ namespace Tacta.EventSourcing.Projections
             return _projectionLock.IsActiveProjection(_activeIdentity).GetAwaiter().GetResult();
         }
 
-        private void OnTimer(object source, ElapsedEventArgs e)
+        public void OnTimer(object source, ElapsedEventArgs e)
         {
             if (_dispatchInProgress)
             {

--- a/Tacta.EventSourcing.Projections/Tacta.EventSourcing.Projections.csproj
+++ b/Tacta.EventSourcing.Projections/Tacta.EventSourcing.Projections.csproj
@@ -9,8 +9,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Provides a simple way of incrementally building / rebuilding read model projections for .NET projects</Description>
     <PackageIconUrl>https://tacta.io//wp-content/uploads/2018/10/tacta_logo_neg.png</PackageIconUrl>
-    <PackageId>ESProjections</PackageId>
-    <Version>1.0.1</Version>
+    <PackageId>TactaESProjections</PackageId>
+    <Version>1.0.4</Version>
   </PropertyGroup>
 
 </Project>

--- a/TactaESProjections.1.0.2.nuspec
+++ b/TactaESProjections.1.0.2.nuspec
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
-    <id>ESProjections</id>
-    <version>1.0.2</version>
+    <id>TactaESProjections</id>
+    <version>1.0.4</version>
     <authors>Tacta.EventSourcing.Projections</authors>
     <owners>Tacta.EventSourcing.Projections</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Projection lock allows only one instance to rehydrate projections.

If one of the instances is unresponsive or unavailable, it will be switch with the next online instance.